### PR TITLE
Fix AttributeError when LLDP Frame is detected

### DIFF
--- a/above.py
+++ b/above.py
@@ -576,7 +576,7 @@ def packet_detection(packet):
 
         hostname = packet[LLDPDUSystemName].system_name.decode() if packet.haslayer(LLDPDUSystemName) else "Not Found"
         os_version = packet[LLDPDUSystemDescription].description.decode() if packet.haslayer(LLDPDUSystemDescription) else "Not Found"
-        port_id = packet[LLDPDUPortID].id.decode() if packet.haslayer(LLDPDUPortID) else "Not Found"
+        port_id = packet[LLDPDUPortID].id.decode() if isinstance(packet[LLDPDUPortID].id, bytes) else packet[LLDPDUPortID].id if packet.haslayer(LLDPDUPortID) else "Not Found"
         print(Fore.GREEN + Style.BRIGHT + "[*] Hostname: " + Fore.WHITE + Style.BRIGHT + hostname)
         print(Fore.GREEN + Style.BRIGHT + "[*] OS Version: " + Fore.WHITE + Style.BRIGHT + os_version)
         print(Fore.GREEN + Style.BRIGHT + "[*] Port ID: " + Fore.WHITE + Style.BRIGHT + port_id)


### PR DESCRIPTION
When an LLDP Frame is detected, an AttributeError occurs. 

Here's the error traceback:

```
[+] Detected LLDP Frame
[*] Attack Impact: Information Gathering
[*] Tools: Wireshark
Traceback (most recent call last):
  File "/usr/bin/above", line 33, in <module>
    sys.exit(load_entry_point('above==2.6', 'console_scripts', 'above')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/above.py", line 824, in main
    sniff(iface=args.interface, timeout=args.timer if args.timer is not None else None, prn=packet_detection, store=0)
  File "/usr/lib/python3/dist-packages/scapy/sendrecv.py", line 1311, in sniff
    sniffer._run(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/scapy/sendrecv.py", line 1254, in _run
    session.on_packet_received(p)
  File "/usr/lib/python3/dist-packages/scapy/sessions.py", line 109, in on_packet_received
    result = self.prn(pkt)
             ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/above.py", line 579, in packet_detection
    port_id = packet[LLDPDUPortID].id.decode() if packet.haslayer(LLDPDUPortID) else "Not Found"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

This issue is due to 'packet[LLDPDUPortID].id' already being a string, thus the decode method can not be used.

To solve this issue, I've implemented a check to only decode the packet if it is a bytes object.